### PR TITLE
Update build to output image map with image URLs for native

### DIFF
--- a/build.js
+++ b/build.js
@@ -121,8 +121,18 @@ async function build() {
   }, {});
 
   fs.outputFileSync(
+    path.join(OUTPUT_FOLDER_RN, "index.js"),
+    format(`module.exports = ${JSON.stringify(imageMap)}`, ".js")
+  );
+
+  fs.outputFileSync(
     path.join(OUTPUT_FOLDER_WEB, "index.js"),
     format(`module.exports = ${JSON.stringify(imageMap)}`, ".js")
+  );
+
+  fs.outputFileSync(
+    path.join(OUTPUT_FOLDER_RN, "index.d.ts"),
+    format(`export default ${JSON.stringify(imageMap)}`, ".js")
   );
 
   fs.outputFileSync(


### PR DESCRIPTION
#### What does this PR do?

This PR updates the build script to output index.js and index.d.ts files with an image map of the illustrations including network image URLs for native in addition to web, this will be included in addition to the static assets which you can still `require`. I want this for cases like the `medicationStatusDetail` where we define the illustration name in API and so it isn't known at build time in the mobileapp, for cases like this we should use [network images](https://reactnative.dev/docs/images#network-images) so that we don't have to bundle all of the possible illustrations (at the moment we're just bundling the ones we know we're using, but that means we would have to do a codepush to support other illustrations).